### PR TITLE
Create Readme with links to another repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Enduro samples
+These are example projects of enduro.js. Most of them are hosted as examples for our blog posts on www.endurojs.com
+
+**Other repositories:** [Enduro](https://github.com/Gottwik/Enduro) • samples • [Enduro admin](https://github.com/Gottwik/enduro_admin) • [endurojs.com site](https://github.com/Gottwik/enduro_website)
+


### PR DESCRIPTION
> This and other recent pull requests simply add wiki-like links to other enduro repos.
> I often find myself navigating between these repos through @Gottwik profile :)
> I feel they should be linked to each other 'cause enduro admin and enduro itself are too tied to each 
other, and linking to samples and website enables better onboarding.

Other PRs: https://github.com/Gottwik/enduro_website/pull/6 • https://github.com/Gottwik/Enduro/pull/75  • https://github.com/Gottwik/enduro_admin/pull/10